### PR TITLE
Update DoubleTransformer.java

### DIFF
--- a/src/main/java/frc/robot/utils/DoubleTransformer.java
+++ b/src/main/java/frc/robot/utils/DoubleTransformer.java
@@ -73,7 +73,7 @@ public class DoubleTransformer implements DoubleSupplier {
      * @return A new {@code DoubleTransformer} with deadzone applied.
      */
     public DoubleTransformer deadzone(double deadzone) {
-        return map((x) -> Math.abs(x) < deadzone ? 0.05 : x);
+        return map((x) -> Math.abs(x) < deadzone ? 0 : x);
     }
 
     /**
@@ -83,7 +83,7 @@ public class DoubleTransformer implements DoubleSupplier {
      * @return A new {@code DoubleTransformer} with deadzone applied.
      */
     public DoubleTransformer deadzone() {
-        return deadzone(0.03);
+        return deadzone(0.05);
     }
 
     /**


### PR DESCRIPTION
Joysticks very rarely center on `0`. Most of the time when you let go of a controller you end up with a value between `[-0.03, 0.03]`. In a lot of applications it's good practice to treat values less than a threshold as `0`.

Your change was incorrect, the existing code treats numbers less than the threshold as `0.05`, meaning that your robot will always command a spin and a drive.

It seems like you may have wanted to raise the default dead-zone threshold to `0.05`. I've done that here.