### PR TITLE
Update SwerveSubsystem.java

### DIFF
--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -55,25 +55,22 @@ public class SwerveSubsystem extends SubsystemBase {
         // TODO set up the auto builder here
         // TODO get max speeds and tune PIDs,
 
-        // Configure the AutoBuilder last
-
         AutoBuilder.configureHolonomic(
-                this::getPose, // Robot pose supplier
-                this::resetPose, // Method to reset odometry (will be called if auto has a starting pose)
-                this::getVelocity, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
-                this::drive, // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds
-                new HolonomicPathFollowerConfig( // HolonomicPathFollowerConfig, this should likely live in your
-                                                 // Constants class
-                        new PIDConstants(1, 0.0, 0.0), // Translation PID constants
-                        new PIDConstants(1, 0.0, 0.0), // Rotation PID constants
-                        4.5, // Max module speed, in m/s
-                        0.4, // Drive base radius in meters. Distance from robot center to furthest module.
-                        new ReplanningConfig() // Default path replanning config. See the API for the options here
-                ), () -> false, // Boolean supplier for flipping auto path
-                this // Swerve subsystem
-
-        );
-
+                this::getPose,
+                this::resetPose,
+                this::getVelocity,
+                this::driveRobotRelative,
+                new HolonomicPathFollowerConfig(
+                        new PIDConstants(5.0, 0.0, 0.0), // Translation PID constants
+                        new PIDConstants(5.0, 0.0, 0.0), // Rotation PID constants
+                        4.5,
+                        m_swerveDrive.swerveDriveConfiguration.getDriveBaseRadiusMeters(),
+                        new ReplanningConfig()),
+                () -> {
+                    var alliance = DriverStation.getAlliance();
+                    return alliance.isPresent() ? alliance.get() == DriverStation.Alliance.Red : false;
+                },
+                this);
     }
 
     @Override
@@ -103,6 +100,13 @@ public class SwerveSubsystem extends SubsystemBase {
      */
     public void drive(ChassisSpeeds chassisSpeeds) {
         m_swerveDrive.driveFieldOriented(chassisSpeeds);
+    }
+
+    /**
+     * Robot-relative swerve drive.
+     */
+    public void driveRobotRelative(ChassisSpeeds chassisSpeeds) {
+        m_swerveDrive.drive(realSpeed);   
     }
 
     /**


### PR DESCRIPTION
PathPlanner requires a _robot relative_ drive command!

We had an odd issue with out autonomous commands spinning out of control, for some reason flipping the rotate velocity worked for us.

https://github.com/FRC5881/2024Robot/blob/c7bbda40efd35c88590692dc1b98115e2b00c509/src/main/java/frc/robot/subsystems/SwerveSubsystem.java#L101